### PR TITLE
fix: preserve geometry precision + switch to AM fork of moleculer-postgis

### DIFF
--- a/services/forms.service.ts
+++ b/services/forms.service.ts
@@ -176,6 +176,7 @@ export interface Form extends BaseModelInterface {
     }),
     PostgisMixin({
       srid: 3346,
+      geojson: { maxDecimalDigits: 2 },
     }),
   ],
 

--- a/services/places.histories.service.ts
+++ b/services/places.histories.service.ts
@@ -31,6 +31,7 @@ export interface PlaceHistory extends BaseModelInterface {
     }),
     PostgisMixin({
       srid: 3346,
+      geojson: { maxDecimalDigits: 2 },
     }),
   ],
 

--- a/services/places.service.ts
+++ b/services/places.service.ts
@@ -74,6 +74,7 @@ export interface Place extends BaseModelInterface {
     }),
     PostgisMixin({
       srid: 3346,
+      geojson: { maxDecimalDigits: 2 },
     }),
   ],
 

--- a/services/requests.service.ts
+++ b/services/requests.service.ts
@@ -117,6 +117,7 @@ const populatePermissions = (field: string) => {
     }),
     PostgisMixin({
       srid: 3346,
+      geojson: { maxDecimalDigits: 2 },
     }),
     Cron,
   ],


### PR DESCRIPTION
## Two fixes in one PR

### 1. Add explicit `maxDecimalDigits` overrides per service

`PostgisMixin` was called without `geojson` options, using the default `{ maxDecimalDigits: 0 }` from `moleculer-postgis`. This causes every `ST_AsGeoJSON` call to round coordinates to integer units on load:
- LKS94 (EPSG:3346, meters) — ~0.7m shift per vertex, vertex merging in complex shapes
- WGS84 (EPSG:4326, degrees) — ~110km shift per degree

Impact verified on biip-rusys-api production: **32% of ~250k forms were re-saved after load under this bug**, irreversibly rounded to integer meters.

Added `geojson: { maxDecimalDigits: 2 }` (or `7` for WGS84) to every `PostgisMixin` call in this repo. Defensive — works even if the library default changes later.

### 2. Switch to AplinkosMinisterija fork of `moleculer-postgis`

The original package (`ambrazasp/moleculer-postgis`) is unmaintained. Switched to [`AplinkosMinisterija/moleculer-postgis`](https://github.com/AplinkosMinisterija/moleculer-postgis) pinned to tag `v0.4.0`, which adds two library-level fixes:

- **SQL injection patch** — `JSON.stringify` in `geometriesAsTextQuery` didn't escape single quotes, enabling SQLi via `crs.properties.name` or feature property strings (time-based blind via `pg_sleep`). Every PostgisMixin consumer was affected. Fixed at library level: consumers no longer need to worry.
- **Default `maxDecimalDigits` changed from `0` to `9`** (PostGIS documented default). Future services using `PostgisMixin({ srid: X })` without explicit options get sane precision out of the box.

Library PR: [AplinkosMinisterija/moleculer-postgis#4](https://github.com/AplinkosMinisterija/moleculer-postgis/pull/4)

`yarn resolutions` is set to also force the fork on transitive deps (e.g. via `@aplinkosministerija/moleculer-accounts`).

## Merge order

1. First merge [AplinkosMinisterija/moleculer-postgis#4](https://github.com/AplinkosMinisterija/moleculer-postgis/pull/4) and confirm tag `v0.4.0` exists on `main`.
2. Then merge this PR.

## Test plan

- [ ] `yarn install` resolves `moleculer-postgis` to the fork (check `yarn.lock` has `codeload.github.com/AplinkosMinisterija/moleculer-postgis/...`)
- [ ] Service starts; form save/load works
- [ ] Existing geometries return with full float precision (not integer meters)
- [ ] New geometries drawn with fine detail (notches, narrow vertices) survive save+reload
- [ ] No regression on spatial queries (intersects, distance, buffer)
