### PR TITLE
fix: filter irrelevant forms and include place geom in request exports

### DIFF
--- a/services/requests.service.ts
+++ b/services/requests.service.ts
@@ -929,11 +929,30 @@ export default class RequestsService extends moleculer.Service {
 
     requestData.places?.forEach((place) => {
       const speciesInfo = getSpeciesData(place.species);
+
+      const placeFeatures = place.geom?.features || [];
+      placeFeatures.forEach((pf: any) => {
+        pf.geometry.crs = { type: 'name', properties: { name: 'EPSG:3346' } };
+        pf.properties = {
+          'Objekto tipas': 'Radavietė',
+          'Radavietės ID': place.id,
+          'Radavietės kodas': place.placeCode,
+          ...speciesInfo,
+          'Radavietės plotas (m²)': place.placeArea,
+          'Paskutinio stebėjimo data': place.placeLastObservedAt,
+          'Pirmo stebėjimo data': place.placeFirstObservedAt,
+          'Radavietės būsena': place.placeStatusTranslate,
+          'Radavietės sukūrimo data': place.placeCreatedAt,
+        };
+        geojson.features.push(pf);
+      });
+
       place.forms?.forEach((form) => {
         const { features } = form.geom || [];
         const featuresToInsert = features.map((f: any) => {
           f.geometry.crs = { type: 'name', properties: { name: 'EPSG:3346' } };
           f.properties = {
+            'Objekto tipas': 'Stebėjimas',
             'Anketos ID': form.id,
             'Radavietės ID': place.id,
             'Radavietės kodas': place.placeCode,

--- a/utils/db.queries.ts
+++ b/utils/db.queries.ts
@@ -193,6 +193,7 @@ export function getFormsByDateAndPlaceIds(ids: number[], date: string) {
     )
     .from(formsTable)
     .whereIn(`${formsTable}.placeId`, ids)
+    .where(knex.raw(`${snakeCase(formsTable)}.${queryBooleanPlain('isRelevant', true)}`))
     .where(`${formsTable}.createdAt`, '<=', date);
 
   return query;


### PR DESCRIPTION
## Reported issues (external feedback on an invasive-species request export)

1. **PDF and GeoJSON exports include forms marked \`isRelevant=false\`** — experts mark observations non-actual, but the external requesting party still sees them.
2. **Place outline (\`radavietės kontūras\`) is missing from the GeoJSON output entirely** — only individual form geometries are emitted.

## Evidence

Case RAD-HER-SOS-197534 (Heracleum sosnowskyi, 3 approved forms linked, 2 marked non-relevant). Previous export leaked all 3 observations with their full geometry and individual counts instead of the curated single relevant record + the place outline.

## Changes

**\`utils/db.queries.ts\` → \`getFormsByDateAndPlaceIds\`**: add \`WHERE isRelevant = true\` filter. Matches the existing filter on \`getInformationalFormsByRequestIds\`. Used only by the PDF renderer and downstream export flows.

**\`services/requests.service.ts\` → \`getGeojson\`**: emit each \`place.geom\` feature alongside form features in the GeoJSON output. Each feature is tagged with an \`\"Objekto tipas\"\` property (\`Radavietė\` vs \`Stebėjimas\`) so recipients can tell them apart inside one \`FeatureCollection\`.

## Test plan

- [ ] Generate a PDF for a request linked to a place that has both relevant and non-relevant approved forms. Verify only relevant ones appear in the \"Radavietės duomenys\" table.
- [ ] Generate GeoJSON for the same request. Verify:
  - Place outline is present as a \`Feature\` with \`properties.\"Objekto tipas\": \"Radavietė\"\` and the place metadata (plotas, stebėjimo datos, būsena)
  - Only relevant form features appear with \`properties.\"Objekto tipas\": \"Stebėjimas\"\`
- [ ] Regression: informational-forms section of GeoJSON remains unchanged (that path was already filtering correctly).