### PR TITLE
security: restrict POST /users/:id/impersonate to ADMIN only

### DIFF
--- a/services/users.service.ts
+++ b/services/users.service.ts
@@ -342,6 +342,7 @@ export default class UsersService extends moleculer.Service {
         convert: true,
       },
     },
+    types: [EndpointType.ADMIN],
   })
   async impersonate(ctx: Context<{ id: number }, UserAuthMeta>) {
     const { id } = ctx.params;


### PR DESCRIPTION
## Summary

Before this change, **any authenticated user could impersonate any other user** (including admins) via `POST /users/:id/impersonate`. The action lacked a `types` restriction, and `auth.validateType` returns `true` when `types` is empty/missing — so the API gateway `authorize()` hook let every logged-in account call this endpoint.

Path:
1. Any authenticated user → `POST /users/<adminUserId>/impersonate`
2. `users.resolve` returns the target user (no scope blocks admins for tenant context, and even regular users could target other users)
3. `auth.users.impersonate` returns an auth token bound to the target user
4. Full account takeover (data filtered by `visibleToUser` / `tenant` scope now resolves against the impersonated user's identity)

## Fix

Add `types: [EndpointType.ADMIN]` so only accounts with `UserType.ADMIN` (resolved by `auth.validateType`) can call this endpoint. Matches the protection pattern already used on `requests.getTasks`, `requests.getRequestPdf`, `forms.getTasks`, etc.

## Test plan

- [ ] As `UserType.USER` (regular), call `POST /users/<X>/impersonate` → expect `401 UNAUTHORIZED` (was: returns an impersonation token).
- [ ] As `UserType.USER` with `isExpert: true`, same call → expect `401`.
- [ ] As `TENANT_ADMIN` (profile context, no global admin), same call → expect `401`.
- [ ] As `UserType.ADMIN` (via biip-auth SUPER_ADMIN local-dev login), same call → expect impersonation token, unchanged behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)