### PR TITLE
security: require auth for request geom and items endpoints

### DIFF
--- a/services/maps.service.ts
+++ b/services/maps.service.ts
@@ -104,10 +104,9 @@ export default class MapsService extends moleculer.Service {
         convert: true,
       },
     },
-    auth: AuthType.PUBLIC,
     rest: 'GET /requests/:id/geom',
   })
-  async getRequestGeom(ctx: Context<{ id: number }>) {
+  async getRequestGeom(ctx: Context<{ id: number }, UserAuthMeta>) {
     const request: Request = await ctx.call('requests.resolve', {
       id: ctx.params.id,
       populate: 'geom',
@@ -205,10 +204,9 @@ export default class MapsService extends moleculer.Service {
         convert: true,
       },
     },
-    auth: AuthType.PUBLIC,
     rest: 'GET /requests/:id/items',
   })
-  async getRequestItems(ctx: Context<{ id: number }>) {
+  async getRequestItems(ctx: Context<{ id: number }, UserAuthMeta>) {
     const { id } = ctx.params;
     const request: Request = await ctx.call('requests.resolve', {
       id: ctx.params.id,


### PR DESCRIPTION
## Summary

`GET /maps/requests/:id/geom` and `GET /maps/requests/:id/items` were marked `auth: AuthType.PUBLIC`. Anyone (unauthenticated) could iterate request IDs (small integers) and read:

- **`/geom`** — the polygon of the territory a requester asked SRIS access to.
- **`/items`** — the list of `places` (radavietės) and `forms` (stebėjimo anketos) belonging to that request.

This leaks the locations of protected / invasive species observation sites that the requester is researching. That dataset is sensitive under LR Saugomų rūšių įstatymas — public access enables poaching, illegal trade, and disturbance of protected habitats.

## Fix

Drop `auth: AuthType.PUBLIC` on both actions. With default Bearer authentication, the existing `visibleToUser` scope on `requests.resolve` automatically restricts visibility to:

- The request creator (when no tenant context),
- Members of the tenant that owns the request,
- `UserType.ADMIN`.

No new scope logic is needed — we are removing an explicit bypass.

## Test plan

- [ ] Anonymous `GET /maps/requests/<X>/geom` → `401` (was: returns geometry).
- [ ] Anonymous `GET /maps/requests/<X>/items` → `401` (was: returns places + forms).
- [ ] Authenticated USER, request created by another user, no shared tenant → `404 NOT_FOUND` (scope filters it out before `throwIfNotExist`).
- [ ] Authenticated USER who created the request → unchanged, returns geometry / items.
- [ ] Authenticated tenant colleague of the creator → unchanged, returns geometry / items.
- [ ] Authenticated ADMIN → unchanged, returns geometry / items for any request.

## Notes

- `maps.service.ts` already imports `UserAuthMeta` from `./api.service`; the action signatures gain that meta type so future scope-aware code reads correctly.
- Other map endpoints in this file (`/qgisserver`, `/auth/me`, `/access/my`) still use `AuthType.MAPS_PRIVATE` — untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)