### PR TITLE
security: enforce per-user access control on minio.getFile (request extracts leak)

### DIFF
--- a/services/minio.service.ts
+++ b/services/minio.service.ts
@@ -13,11 +13,18 @@ import {
   getPublicFileName,
   throwNotFoundError,
   throwUnableToUploadError,
+  throwUnauthorizedError,
   throwUnsupportedMimetypeError,
 } from '../types';
 import { AuthType, UserAuthMeta } from './api.service';
+import { UserType } from './users.service';
 
 export const BUCKET_NAME = () => process.env.MINIO_BUCKET || 'rusys';
+
+// Object paths that may be served without authentication. These mirror the
+// MinIO bucket policy applied at service start (uploads/forms/* and
+// uploads/species/* are public-read for image rendering).
+const PUBLIC_PATH_PREFIXES = ['uploads/forms/', 'uploads/species/'];
 
 @Service({
   name: 'minio',
@@ -172,7 +179,7 @@ export default class MinioService extends Moleculer.Service {
   async getFile(
     ctx: Context<
       { bucket: string; name: string[]; download?: string },
-      {
+      UserAuthMeta & {
         $responseHeaders: any;
         $statusCode: number;
         $statusMessage: string;
@@ -181,11 +188,14 @@ export default class MinioService extends Moleculer.Service {
     >,
   ) {
     const { bucket, name } = ctx.params;
+    const objectPath = name.join('/');
+
+    await this.assertCanReadObject(ctx, objectPath);
 
     try {
       const reader: NodeJS.ReadableStream = await ctx.call('minio.getObject', {
         bucketName: bucket,
-        objectName: name.join('/'),
+        objectName: objectPath,
       });
 
       const filename = name[name.length - 1];
@@ -340,6 +350,60 @@ export default class MinioService extends Moleculer.Service {
     }
 
     return `${hostUrl}/${bucketName}/${objectName}`;
+  }
+
+  @Method
+  async assertCanReadObject(
+    ctx: Context<unknown, UserAuthMeta>,
+    objectPath: string,
+  ): Promise<void> {
+    if (PUBLIC_PATH_PREFIXES.some((prefix) => objectPath.startsWith(prefix))) {
+      return;
+    }
+
+    const user = ctx.meta.user;
+    if (!user?.id) {
+      throwUnauthorizedError('Authentication required.');
+    }
+
+    if (user.type === UserType.ADMIN) {
+      return;
+    }
+
+    // Request extracts (PDF / GeoJSON) live under:
+    //   uploads/requests/<tenantId or 'private'>/<userId or 'user'>/<filename>
+    // See requests.service.ts and jobs.requests.service.ts -> getFolderName.
+    const requestPathMatch = objectPath.match(
+      /^uploads\/requests\/([^/]+)\/([^/]+)\//,
+    );
+
+    if (!requestPathMatch) {
+      throwUnauthorizedError('Cannot access this file.');
+    }
+
+    const [, tenantSegment, userSegment] = requestPathMatch;
+
+    if (tenantSegment === 'private') {
+      // Personal (non-tenant) folder: only the owning user may read.
+      if (String(user.id) !== userSegment) {
+        throwUnauthorizedError('Cannot access this file.');
+      }
+      return;
+    }
+
+    const tenantId = Number(tenantSegment);
+    if (!Number.isFinite(tenantId) || tenantId <= 0) {
+      throwUnauthorizedError('Cannot access this file.');
+    }
+
+    const isMember: boolean = await ctx.call('tenantUsers.userExistsInTenant', {
+      userId: user.id,
+      tenantId,
+    });
+
+    if (!isMember) {
+      throwUnauthorizedError('Cannot access this file.');
+    }
   }
 
   @Method


### PR DESCRIPTION
## Summary

`GET /minio/:bucket/:name+` (`minio.getFile`) was marked `auth: AuthType.PUBLIC` with the bucket and object path fully user-controlled. Because every generated request extract is uploaded with `isPrivate: true` into the predictable folder layout

```
uploads/requests/<tenantId | 'private'>/<userId | 'user'>/israsas-<requestId>.<pdf|geojson>
```

**any anonymous user could iterate small integers and download the PDF / GeoJSON extracts of arbitrary requests**, including the protected species observation coordinates they contain (sensitive under LR Saugomų rūšių įstatymas) plus personal data (requester name, contact data, signatures embedded in PDF).

The presigned-URL flow is unaffected — those go directly to MinIO over its own signed-URL gateway. This PR only locks the proxied path via our API.

## Fix

Introduce `assertCanReadObject(ctx, objectPath)` that runs before the MinIO read in `getFile`:

| Path | Who can read |
|---|---|
| `uploads/forms/*`, `uploads/species/*` | anyone (matches the MinIO bucket policy applied in `started()`) |
| `uploads/requests/<tenantId>/<userId>/...` | any member of that tenant (via `tenantUsers.userExistsInTenant`), or `UserType.ADMIN` |
| `uploads/requests/private/<userId>/...` | only the owning user (`String(user.id) === userSegment`), or `UserType.ADMIN` |
| any other private path | `UserType.ADMIN` only |
| any private path, unauthenticated | `401` |

This matches the team's intended access model: tenant colleagues see each other's extracts; users only see their own personal (non-tenant) extracts; admins see everything; species photos and form photos stay public.

`auth: AuthType.PUBLIC` is kept on the action so unauthenticated requests for `uploads/forms/*` and `uploads/species/*` (used for inline image rendering on the public website) still pass through the gateway. When a bearer token is presented, `authenticate()` populates `ctx.meta.user` normally; the access check inside the action then decides.

`yarn build` passes locally.

## Test plan

Public paths (no token):
- [ ] `GET /minio/rusys/uploads/forms/<file>.png` → 200
- [ ] `GET /minio/rusys/uploads/species/<file>.jpg` → 200

Private — anonymous:
- [ ] `GET /minio/rusys/uploads/requests/private/5/israsas-1.pdf` → 401 (was: 200 with PDF body)
- [ ] `GET /minio/rusys/uploads/requests/12/5/israsas-1.pdf` → 401 (was: 200 with PDF body)

Private — authenticated owner:
- [ ] User 5 fetches `uploads/requests/private/5/israsas-1.pdf` → 200
- [ ] User 5 fetches `uploads/requests/private/6/israsas-1.pdf` → 401

Tenant colleague:
- [ ] User 5 is member of tenant 12 → can read `uploads/requests/12/<anyone>/israsas-X.<pdf|geojson>` → 200
- [ ] User 5 not a member of tenant 99 → `uploads/requests/99/.../israsas-X.pdf` → 401

Admin:
- [ ] `UserType.ADMIN` fetches any path under `uploads/requests/**` → 200

Edge:
- [ ] Authenticated non-admin fetching an unknown private path (e.g. `uploads/temp/screenshots/X.jpeg`) → 401 (presigned URL still works through MinIO directly).
- [ ] Authenticated user with a non-numeric tenant segment in the path → 401.

🤖 Generated with [Claude Code](https://claude.com/claude-code)