### PR TITLE
feat(api): add security headers via helmet + Permissions-Policy

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "dotenv": "^16.0.0",
     "ejs": "^3.1.8",
     "geojsonjs": "^0.1.2",
+    "helmet": "^8.1.0",
     "ioredis": "^4.28.5",
     "jsonwebtoken": "^9.0.0",
     "knex": "^2.5.1",

--- a/services/api.service.ts
+++ b/services/api.service.ts
@@ -1,3 +1,5 @@
+import { Handlers } from '@sentry/node';
+import helmet from 'helmet';
 import pick from 'lodash/pick';
 import moleculer, { Context, Errors } from 'moleculer';
 import { Action, Method, Service } from 'moleculer-decorators';
@@ -6,7 +8,19 @@ import { COMMON_DELETED_SCOPES, EndpointType, RequestMessage } from '../types';
 import { Tenant } from './tenants.service';
 import { User } from './users.service';
 import { throwUnauthorizedError } from '../types';
-import { Handlers } from '@sentry/node';
+
+// Permissions-Policy is intentionally NOT covered by helmet (it dropped
+// Feature-/Permissions-Policy support), so set it explicitly. Disables a set
+// of powerful browser features this JSON API never needs, shrinking the
+// attack surface if a response is ever rendered in a browsing context.
+function permissionsPolicyMiddleware(_req: any, res: any, next: any) {
+  res.setHeader(
+    'Permissions-Policy',
+    'accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()',
+  );
+  next();
+}
+
 export interface UserAuthMeta {
   user: User;
   profile?: Tenant;
@@ -42,6 +56,14 @@ export const AuthType = {
     },
 
     use: [
+      // Standard security headers (X-Content-Type-Options, X-Frame-Options,
+      // Referrer-Policy, COOP/CORP, HSTS in prod, drops X-Powered-By, etc.)
+      // applied to every route. CSP is intentionally disabled: this API
+      // serves binary files through the `minio` proxy, and a wrong CSP would
+      // break inline file responses without protecting a JSON/file surface.
+      // Permissions-Policy (which helmet no longer sets) is added separately.
+      helmet({ contentSecurityPolicy: false }),
+      permissionsPolicyMiddleware,
       function (req: any, res: any, next: any) {
         const removeScopes = (query: any) => {
           if (!query) return query;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3207,6 +3207,11 @@ hasown@^2.0.0:
   dependencies:
     function-bind "^1.1.2"
 
+helmet@^8.1.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/helmet/-/helmet-8.2.0.tgz#61cb43244de24255a288c2fddb36086074eb1812"
+  integrity sha512-DRgTIUgnWcJ62KyarxxziuqYxKGnR6Rgg19BlbucN/dpmJbl1XOit6qvoOX0ZT+HhWe5OUVhU/a1zpGyc1xA0Q==
+
 html-encoding-sniffer@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz#42a6dc4fd33f00281176e8b23759ca4e4fa185f3"


### PR DESCRIPTION
## What

Wires **helmet** into the API gateway global middleware chain, bringing `biip-rusys-api` in line with the security-headers convention already used across the other biip APIs (zvejyba, uetk, medziokle, gyvunai, hidro, auth, zuvinimas, alis, tools).

## Why

`biip-rusys-api` was the only file-serving biip API with **no** security response headers at all. This adds the standard baseline.

## Changes

- `helmet({ contentSecurityPolicy: false })` added to the **global** `settings.use` array, so it covers every route (`/public`, `/auth`, and the main `**` route) — not just one.
  - Sets `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`, `Cross-Origin-Opener-Policy`, `Cross-Origin-Resource-Policy`, HSTS (prod), and drops `X-Powered-By`.
  - **CSP intentionally disabled** — this API serves binary files through the `minio` proxy; a wrong CSP would break inline file responses without protecting a JSON/file surface. Same rationale as `biip-zvejyba-api`.
- `permissionsPolicyMiddleware` — sets `Permissions-Policy` explicitly, because helmet **no longer** manages it (it dropped Feature-/Permissions-Policy support). Locks down browser features the API never needs.

## Verification

- `tsc --build` — clean
- `eslint` — clean
- Runtime smoke: invoked the exact middleware chain against a mock response — confirmed all expected headers present, CSP absent, `Permissions-Policy` set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)