### PR TITLE
rusys: restrict place reads to admins/experts and remove client-settable maps server token

### DIFF
--- a/services/maps.service.ts
+++ b/services/maps.service.ts
@@ -236,7 +236,7 @@ export default class MapsService extends moleculer.Service {
   @Action({
     rest: 'GET /auth',
   })
-  async generateToken(ctx: Context<{ server?: boolean }, UserAuthMeta>) {
+  async generateToken(ctx: Context<{}, UserAuthMeta>) {
     const { user } = ctx.meta;
 
     if (user?.id && !user.isExpert && user.type !== UserType.ADMIN) {
@@ -252,11 +252,22 @@ export default class MapsService extends moleculer.Service {
       tenantId: ctx.meta.profile?.id,
     };
 
-    if (ctx.params.server) {
-      data.s = 1;
-    }
-
     const token = await this.generateTokenFromPayload(data);
+
+    return {
+      token,
+      expires: moment().add(1, 'day').format(),
+    };
+  }
+
+  // A server token (`s: 1`) resolves to `isServer`, which bypasses all
+  // authorization and map layer filtering — it is strictly for internal
+  // server-side rendering (PDF/screenshot generation). This action has no REST
+  // alias, so it is reachable only via service-to-service calls; the privilege
+  // must never be derivable from a client-supplied request parameter.
+  @Action()
+  async generateServerToken(ctx: Context) {
+    const token = await this.generateTokenFromPayload({ s: 1 });
 
     return {
       token,

--- a/services/places.service.ts
+++ b/services/places.service.ts
@@ -186,6 +186,29 @@ export interface Place extends BaseModelInterface {
       },
       types: [EndpointType.ADMIN, EndpointType.EXPERT],
     },
+
+    // Places hold precise protected-species coordinates. The `visibleToExpert`
+    // scope only narrows experts (to their own species) and lets admins through,
+    // so without a gate a plain USER would read every place. Regular users get
+    // their granted places through the maps/QGIS flow (maps.qgisserver), not
+    // these endpoints, so restrict the reads to admins and experts — matching
+    // the create/update/remove restriction above. Internal populate/resolve
+    // calls are unaffected (service-to-service calls bypass endpoint `types`).
+    get: {
+      types: [EndpointType.ADMIN, EndpointType.EXPERT],
+    },
+
+    list: {
+      types: [EndpointType.ADMIN, EndpointType.EXPERT],
+    },
+
+    find: {
+      types: [EndpointType.ADMIN, EndpointType.EXPERT],
+    },
+
+    count: {
+      types: [EndpointType.ADMIN, EndpointType.EXPERT],
+    },
   },
 })
 export default class PlacesService extends moleculer.Service {
@@ -197,6 +220,7 @@ export default class PlacesService extends moleculer.Service {
         convert: true,
       },
     },
+    types: [EndpointType.ADMIN, EndpointType.EXPERT],
   })
   async getHistory(ctx: Context<{ id: number }>) {
     return ctx.call(`places.histories.list`, {
@@ -288,6 +312,7 @@ export default class PlacesService extends moleculer.Service {
 
   @Action({
     rest: 'GET /deleted',
+    types: [EndpointType.ADMIN, EndpointType.EXPERT],
   })
   listDeleted(ctx: Context<{}>) {
     return ctx.call('places.list', {

--- a/utils/pdf/requests.ts
+++ b/utils/pdf/requests.ts
@@ -107,9 +107,7 @@ async function getTranslatesAndFormTypes(ctx: Context, speciesIds: number[]) {
 }
 
 export async function getMapsSearchParams(ctx: Context): Promise<URLSearchParams> {
-  const mapsToken: any = await ctx.call('maps.generateToken', {
-    server: true,
-  });
+  const mapsToken: any = await ctx.call('maps.generateServerToken');
 
   const searchParams = new URLSearchParams();
   searchParams.set('auth', mapsToken.token);


### PR DESCRIPTION
## What

Closes two authorization holes that let a regular authenticated user reach protected-species location data they should not:

1. **Place reads gated to ADMIN/EXPERT.** `places` `list` / `find` / `get` / `count` / `GET /:id/history` / `GET /deleted` had no endpoint `types`, and the `visibleToExpert` scope only narrows experts (to their own species) and passes admins through. A plain USER matched neither branch, so `GET /places/all` returned **every** radavietė (precise `geom`), bypassing the request/approval ("išrašai") flow. Reads are now restricted to admins and experts, matching the existing create/update/remove restriction.

2. **Maps server token is no longer client-settable.** `maps.generateToken` (`GET /maps/auth`) set the `s` (server) JWT claim straight from a `?server=1` query param. A server token resolves to `isServer`, which bypasses all authorization and map-layer filtering — so a user with one approved GET request could mint one and view all species locations. The client flag is dropped; server tokens are now minted only via a new internal-only `maps.generateServerToken` action (no REST alias), called by the PDF generation flow.

## Why

Both defeated the core access control of the system: precise protected-species coordinates are supposed to be reachable only via an approved request (rendered through the maps/QGIS flow), yet either issue exposed the full dataset to any regular account.

## Notes

- **No impact on the regular-user map.** Both `biip-rusys-web` and the legacy `biip-rusys` frontend display radavietės via the `maps.biip.lt` iframe → `maps.qgisserver` (QGIS, per-user filtered in `computeFilterValue`), never via the `places` REST endpoints. Neither FE calls `/places` (the `PLACES` resource constant is unused).
- **Internal calls unaffected.** All `places.resolve` / `places.find` populates and `ctx.call('places.*')` are service-to-service and bypass endpoint `types`, so form/PDF/place-management flows keep working.
- The server-token change is behaviourally identical for the PDF flow — the minted token is still `{ s: 1 }`.
- Verify after deploy: `GET /places/all` with a plain-USER token → `401`; expert token → only their species; the radavietė map + request-PDF generation still render.

Part of a wider read-only security review; remaining P1/P2 findings (self-promotion to TENANT_ADMIN via `PATCH /users/:id`, unauthenticated request IDOR, unauthenticated file/HTML access) are tracked separately.


Closes #151