### PR TITLE
rusys: block tenant-admin self-promotion + harden request-HTML secret, cache-clean, logging

### DIFF
--- a/services/api.service.ts
+++ b/services/api.service.ts
@@ -196,10 +196,11 @@ export const AuthType = {
     ],
     // Do not log client side errors (does not log an error response when the error.code is 400<=X<500)
     log4XXResponses: false,
-    // Logging the request parameters. Set to any log level to enable it. E.g. "info"
-    logRequestParams: "info",
-    // Logging the response data. Set to any log level to enable it. E.g. "info"
-    logResponseData: "info",
+    // Request params and response bodies carry secrets (auth/maps tokens, the
+    // request HTML `secret`, private file URLs, protected-species data), so they
+    // must not be written to logs. Keep both disabled (null).
+    logRequestParams: null,
+    logResponseData: null,
     // Serve assets from "public" folder
     assets: {
       folder: 'public',

--- a/services/jobs.requests.service.ts
+++ b/services/jobs.requests.service.ts
@@ -6,7 +6,7 @@ import moment from 'moment';
 import { PassThrough, Readable } from 'stream';
 import BullMqMixin from '../mixins/bullmq.mixin';
 import { FILE_TYPES, throwNotFoundError, throwValidationError } from '../types';
-import { toMD5Hash, toReadableStream } from '../utils/functions';
+import { toHmacHash, toMD5Hash, toReadableStream } from '../utils/functions';
 import { getTemplateHtml } from '../utils/html';
 import {
   getInformationalForms,
@@ -21,7 +21,15 @@ import { Tenant } from './tenants.service';
 import { User } from './users.service';
 
 export function getRequestSecret(request: Request) {
-  return toMD5Hash(`id=${request.id}&date=${moment(request.createdAt).format('YYYYMMDDHHmmss')}`);
+  // Gates the public request HTML endpoint. `id` is an enumerable integer and
+  // `createdAt` is returned on the request, so a keyless md5 of them was
+  // forgeable; key the digest with a server secret so it cannot be recomputed
+  // from public data. Both generation and validation call this, so the shared
+  // key keeps them in sync with no stored state.
+  return toHmacHash(
+    `id=${request.id}&date=${moment(request.createdAt).format('YYYYMMDDHHmmss')}`,
+    process.env.JWT_MAPS_SECRET,
+  );
 }
 @Service({
   name: 'jobs.requests',

--- a/services/public.service.ts
+++ b/services/public.service.ts
@@ -2,7 +2,7 @@
 
 import moleculer, { Context } from 'moleculer';
 import { Action, Method, Service } from 'moleculer-decorators';
-import { DBPagination, throwNotFoundError } from '../types';
+import { DBPagination, EndpointType, throwNotFoundError } from '../types';
 import { AuthType } from './api.service';
 import { Convention } from './conventions.service';
 import { Taxonomy } from './taxonomies.service';
@@ -66,9 +66,11 @@ export default class PublicService extends moleculer.Service {
     };
   }
 
+  // Flushing the whole cache is an admin-only maintenance action — it was
+  // unauthenticated, letting anyone repeatedly wipe the cache (availability).
   @Action({
     rest: 'POST /cache/clean',
-    auth: AuthType.PUBLIC,
+    types: [EndpointType.ADMIN],
   })
   cleanCache() {
     this.broker.cacher.clean();

--- a/services/tenantUsers.service.ts
+++ b/services/tenantUsers.service.ts
@@ -517,12 +517,20 @@ export default class TenantUsersService extends moleculer.Service {
     types: [EndpointType.ADMIN, EndpointType.TENANT_ADMIN],
   })
   async updateUser(ctx: Context<{ userId: number; tenantId: number; role: string }, UserAuthMeta>) {
-    const { profile } = ctx.meta;
+    const { user: currentUser, profile } = ctx.meta;
     const { userId, tenantId, role } = ctx.params;
-    if (
-      profile?.id &&
-      (Number(profile?.id) !== tenantId || profile?.role !== TenantUserRole.ADMIN)
-    ) {
+
+    // Only a system admin, or the tenant's own admin acting on that tenant, may
+    // change a member's role. A missing profile must NOT be treated as
+    // authorized: this action is also reached internally from
+    // `users.updateUser` (PATCH /users/:id), which any member can call without
+    // an `x-profile` header — otherwise a plain member could promote themselves
+    // to TENANT_ADMIN here.
+    const isSystemAdmin = currentUser?.type === UserType.ADMIN;
+    const isTenantAdmin =
+      !!profile?.id && Number(profile.id) === tenantId && profile.role === TenantUserRole.ADMIN;
+
+    if (!isSystemAdmin && !isTenantAdmin) {
       throw new moleculer.Errors.MoleculerClientError(
         'Tenant is not accessable.',
         401,

--- a/utils/functions.ts
+++ b/utils/functions.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'crypto';
+import { createHash, createHmac } from 'crypto';
 import { Readable } from 'stream';
 
 export function toReadableStream(fetchReadable: any): NodeJS.ReadableStream {
@@ -22,6 +22,12 @@ export function toReadableStream(fetchReadable: any): NodeJS.ReadableStream {
 
 export function toMD5Hash(text: string) {
   return createHash('md5').update(text).digest('hex');
+}
+
+// Keyed hash — use where the digest is a capability/authorization token so it
+// cannot be forged from public inputs (unlike a plain, keyless md5/sha).
+export function toHmacHash(text: string, secret: string) {
+  return createHmac('sha256', secret).update(text).digest('hex');
 }
 
 export function parseToObject(data: object | string) {


### PR DESCRIPTION
Follow-up to #149 — the remaining privilege-escalation / hardening findings from the same review that are fixable API-side without a coordinated frontend change.

## What

1. **Block self-promotion to TENANT_ADMIN (P1).** `tenantUsers.updateUser` skipped its ownership check whenever no `x-profile` header was present. Because `users.updateUser` (`PATCH /users/:id`) reaches it through an internal call, a plain company member could send `PATCH /users/<ownId>` with no `x-profile` and `{role:"ADMIN", tenantId:<their tenant>}` and make themselves the company admin. The guard now requires a **system admin** or the **tenant's own admin acting on that tenant** — a missing profile is no longer treated as authorized.

2. **Harden the request-HTML secret (P2).** The public `GET /jobs/requests/:id/html` endpoint (used by the PDF renderer) was gated by `md5(id + createdAt)`. `id` is an enumerable integer and `createdAt` is returned on the request, so the digest was forgeable/brute-forceable. It is now an HMAC-SHA256 keyed by a server secret (`JWT_MAPS_SECRET`).

3. **Restrict cache flush to ADMIN (P2).** `POST /cache/clean` called `cacher.clean()` with `auth: PUBLIC` — anyone could repeatedly wipe the cache. Now `types: [ADMIN]`.

4. **Stop logging secrets (P2).** `logRequestParams` / `logResponseData` were `"info"`, writing auth/maps tokens, the request-HTML `secret` query param, private file URLs and protected-species data into logs. Both disabled.

## Why

Item 1 is a real vertical privilege escalation (regular employee → company admin). The rest reduce the blast radius of the sensitive "išrašai" data (forgeable extract access, log leakage) and an unauthenticated availability hole.

## Notes

- **Tenant-admin role changes still work:** the frontend attaches `X-Profile` on every request via an axios interceptor (`biip-rusys-web/src/api.ts`), so a company admin's role change carries `X-Profile` and passes the new check; system admins (no profile) pass via the admin branch. Self email/phone updates via `PATCH /users/:id` don't touch role and are unaffected.
- The HMAC change has **no stored state** — both the PDF generation and the HTML validation call `getRequestSecret`, so they stay in sync; a dedicated secret (instead of reusing `JWT_MAPS_SECRET`) would be marginally cleaner but needs infra wiring.
- Typecheck + lint clean.

## Deliberately NOT included (need more than an API-only change)

- **Unauthenticated IDOR on `GET /maps/requests/:id/{geom,items}`** — `biip-maps-web` fetches these token-less as OpenLayers layer sources (`routes/rusys.vue`, `utils/requests/rusys.ts`), so making them non-public would break the map. Needs a coordinated frontend change (per-request capability token or scoped auth).
- **`minio.getFile` serving request extracts without an ownership check** — needs a design decision (auth + ownership vs short-lived presigned URLs) and also serves the public species/form photos, so it warrants its own PR.


Closes #152