### PR TITLE
rusys: recompute place geometry when a form's relevancy changes

### DIFF
--- a/database/migrations/20260723120000_recomputePlacesWithIrrelevantForms.js
+++ b/database/migrations/20260723120000_recomputePlacesWithIrrelevantForms.js
@@ -1,0 +1,47 @@
+/**
+ * Backfill for places whose geom still includes forms that were marked
+ * irrelevant via PATCH /forms/:id — that path never emitted places.changed,
+ * so the place was never recomputed (fixed in forms.service.ts alongside
+ * this migration).
+ *
+ * Scoped to places that have at least one APPROVED irrelevant form; only
+ * rows whose recomputed geom actually differs are updated, so the migration
+ * is idempotent. Places whose approved forms are ALL irrelevant (historic
+ * data) recompute to NULL geom and are left untouched.
+ *
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+  return knex.schema
+    .raw(
+      `UPDATE places p
+       SET geom = d.geom
+       FROM (
+         SELECT p2.id, r.geom
+         FROM (
+           SELECT DISTINCT f.place_id AS id
+           FROM forms f
+           WHERE f.status = 'APPROVED'
+             AND f.is_relevant IS NOT TRUE
+             AND f.place_id IS NOT NULL
+         ) candidates
+         JOIN places p2 ON p2.id = candidates.id AND p2.deleted_at IS NULL
+         CROSS JOIN LATERAL rusys_get_place_data_from_relevant_forms(p2.id::int) r
+         WHERE r.geom IS NOT NULL
+       ) d
+       WHERE p.id = d.id
+         AND (p.geom IS NULL OR NOT ST_Equals(p.geom, d.geom))`,
+    )
+    .refreshMaterializedView('placesWithTaxonomies');
+};
+
+/**
+ * Data repair — nothing to restore.
+ *
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function () {
+  return Promise.resolve();
+};

--- a/database/migrations/20260723120000_recomputePlacesWithIrrelevantForms.js
+++ b/database/migrations/20260723120000_recomputePlacesWithIrrelevantForms.js
@@ -15,6 +15,12 @@
 exports.up = function (knex) {
   return knex.schema
     .raw(
+      // forms.place_id has no index; with ~500k forms in production every
+      // per-place recompute (this backfill AND every places.changed at
+      // runtime) would seq-scan the whole table without it.
+      `CREATE INDEX IF NOT EXISTS forms_place_id_idx ON forms (place_id)`,
+    )
+    .raw(
       `UPDATE places p
        SET geom = d.geom
        FROM (
@@ -37,11 +43,11 @@ exports.up = function (knex) {
 };
 
 /**
- * Data repair — nothing to restore.
+ * Data repair — only the index is reversible.
  *
  * @param { import("knex").Knex } knex
  * @returns { Promise<void> }
  */
-exports.down = function () {
-  return Promise.resolve();
+exports.down = function (knex) {
+  return knex.schema.raw(`DROP INDEX IF EXISTS forms_place_id_idx`);
 };

--- a/services/forms.service.ts
+++ b/services/forms.service.ts
@@ -29,7 +29,7 @@ import {
 import { UserAuthMeta } from './api.service';
 
 import _ from 'lodash';
-import { parseToObject } from '../utils/functions';
+import { parseToObject, shouldRecomputePlaceOnRelevancyChange } from '../utils/functions';
 import { emailCanBeSent, notifyFormAssignee, notifyOnFormUpdate } from '../utils/mails';
 import { FormHistoryTypes } from './forms.histories.service';
 import { FormSettingSource } from './forms.settings.sources.service';
@@ -1098,8 +1098,12 @@ export default class FormsService extends moleculer.Service {
       ids = [ids];
     }
 
+    // Place geometry derives from APPROVED relevant forms only — counting
+    // non-approved ones here would let the last approved relevant form go
+    // irrelevant and leave the place with an empty geometry.
     const query: any = {
       isRelevant: queryBoolean('isRelevant', true),
+      status: FormStatus.APPROVED,
     };
 
     if (ids?.length) {
@@ -1579,6 +1583,19 @@ export default class FormsService extends moleculer.Service {
         } else {
           await this.assignPlaceIfNeeded(ctx, prevForm);
         }
+      }
+    }
+
+    if (
+      shouldRecomputePlaceOnRelevancyChange(form, prevForm, ctx.options?.parentCtx?.action?.name)
+    ) {
+      const { comment } = (ctx.options?.parentCtx?.params as { comment?: string }) || {};
+      try {
+        await ctx.emit('places.changed', { id: form.place, comment });
+      } catch (err) {
+        // A failed recompute must not turn into an unhandled rejection —
+        // the relevancy change itself is already persisted.
+        this.logger.error('Failed to recompute place after form relevancy change', err);
       }
     }
 

--- a/utils/functions.spec.ts
+++ b/utils/functions.spec.ts
@@ -1,0 +1,79 @@
+import { shouldRecomputePlaceOnRelevancyChange } from './functions';
+
+describe('shouldRecomputePlaceOnRelevancyChange', () => {
+  const approvedForm = {
+    isRelevant: false,
+    isInformational: false,
+    status: 'APPROVED',
+    place: 10,
+  };
+  const prevRelevantForm = { ...approvedForm, isRelevant: true };
+
+  it('recomputes when a single approved form with a place changes relevancy', () => {
+    expect(
+      shouldRecomputePlaceOnRelevancyChange(approvedForm, prevRelevantForm, 'forms.update'),
+    ).toBe(true);
+  });
+
+  it('recomputes when relevancy is restored back to relevant', () => {
+    expect(
+      shouldRecomputePlaceOnRelevancyChange(prevRelevantForm, approvedForm, 'forms.update'),
+    ).toBe(true);
+  });
+
+  it('skips when relevancy did not change', () => {
+    expect(shouldRecomputePlaceOnRelevancyChange(approvedForm, approvedForm, 'forms.update')).toBe(
+      false,
+    );
+  });
+
+  it('skips batch updates — places.updateForms emits places.changed itself', () => {
+    expect(
+      shouldRecomputePlaceOnRelevancyChange(approvedForm, prevRelevantForm, 'forms.updateBatch'),
+    ).toBe(false);
+  });
+
+  it('skips event-driven bulk flagging (places.removed) where parent action is absent', () => {
+    expect(shouldRecomputePlaceOnRelevancyChange(approvedForm, prevRelevantForm)).toBe(false);
+  });
+
+  it('skips forms without a place', () => {
+    expect(
+      shouldRecomputePlaceOnRelevancyChange(
+        { ...approvedForm, place: undefined },
+        { ...prevRelevantForm, place: undefined },
+        'forms.update',
+      ),
+    ).toBe(false);
+  });
+
+  it('skips when the place changed in the same update — handled by the place-change branch', () => {
+    expect(
+      shouldRecomputePlaceOnRelevancyChange(
+        { ...approvedForm, place: 11 },
+        prevRelevantForm,
+        'forms.update',
+      ),
+    ).toBe(false);
+  });
+
+  it('skips non-approved forms', () => {
+    expect(
+      shouldRecomputePlaceOnRelevancyChange(
+        { ...approvedForm, status: 'CREATED' },
+        { ...prevRelevantForm, status: 'CREATED' },
+        'forms.update',
+      ),
+    ).toBe(false);
+  });
+
+  it('skips informational forms — they never shape place geometry', () => {
+    expect(
+      shouldRecomputePlaceOnRelevancyChange(
+        { ...approvedForm, isInformational: true },
+        { ...prevRelevantForm, isInformational: true },
+        'forms.update',
+      ),
+    ).toBe(false);
+  });
+});

--- a/utils/functions.ts
+++ b/utils/functions.ts
@@ -24,6 +24,40 @@ export function toMD5Hash(text: string) {
   return createHash('md5').update(text).digest('hex');
 }
 
+const FORMS_SINGLE_UPDATE_ACTION = 'forms.update';
+
+interface RelevancyRecomputeForm {
+  isRelevant?: boolean;
+  isInformational?: boolean;
+  status?: string;
+  place?: number | object;
+}
+
+/**
+ * Place geom derives from relevant forms only, so a single-form relevancy
+ * change must recompute its place. Only the direct update (PATCH /forms/:id)
+ * qualifies: bulk paths must not recompute per form — places.updateForms
+ * emits one places.changed itself (per-form emissions would duplicate place
+ * history entries), and places.removed flags the forms of an already-removed
+ * place, where a recompute would throw on empty geometry.
+ */
+export function shouldRecomputePlaceOnRelevancyChange(
+  form: RelevancyRecomputeForm,
+  prevForm?: RelevancyRecomputeForm,
+  parentActionName?: string,
+): boolean {
+  const relevancyChanged = prevForm?.isRelevant !== form.isRelevant;
+
+  return (
+    relevancyChanged &&
+    parentActionName === FORMS_SINGLE_UPDATE_ACTION &&
+    !!form.place &&
+    form.place === prevForm?.place &&
+    form.status === 'APPROVED' &&
+    !form.isInformational
+  );
+}
+
 export function parseToObject(data: object | string) {
   if (typeof data === 'string') {
     try {


### PR DESCRIPTION
## What
Fixes the map showing data of an irrelevant anketa (project item 216848727): marking a single observation form irrelevant via `PATCH /forms/:id` (admin-web ObservationForm toggle) only refreshed the `approved_forms` view — `places.changed` was never emitted, so the place polygon kept the irrelevant form's footprint on the QGIS `radavietes` layer.

- `forms.updated` now emits `places.changed` when an approved, non-informational form with a place changes relevancy — only for the direct `forms.update` action. Bulk paths are deliberately excluded: `places.updateForms` emits a single `places.changed` itself, and `places.removed` flags forms of an already-removed place (a recompute there would throw on empty geometry).
- `forms.relevantFormsCount` now counts only APPROVED forms — place geometry derives solely from approved relevant forms, so the previous count allowed the last approved relevant form to go irrelevant, leaving an empty-geometry place.
- Migration backfills places already stale from this bug (scoped to places with ≥1 approved irrelevant form, idempotent, NULL-geom places skipped) and refreshes `places_with_taxonomies`. It intentionally writes no `place_histories` rows — it is a data repair, not an expert action.

## Notes
- Verified live on a fresh local DB: seeded a place whose geom contained a relevant + an irrelevant form footprint — the migration shrank `places.geom` and `places_with_taxonomies` to the relevant footprint only; re-run is a no-op.
- Guard logic extracted to `shouldRecomputePlaceOnRelevancyChange` with unit tests (`utils/functions.spec.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
- Scale-tested against production-like volume: 482k forms / 20k places / 2k stale candidates seeded locally — the whole migration (new `forms_place_id_idx` + backfill + matview refresh) runs in ~7s; all 2k candidates repaired, all 18k non-candidates untouched. The index also removes a full-table scan from every runtime `places.changed` recompute.
