### PR TITLE
rusys: show only relevant forms' info in place map popup

### DIFF
--- a/database/migrations/20260723130000_filterRelevantFormsInPlacesWithTaxonomiesView.js
+++ b/database/migrations/20260723130000_filterRelevantFormsInPlacesWithTaxonomiesView.js
@@ -1,0 +1,215 @@
+/**
+ * The map identify popup (SRIS `radavietes`, INVA `radavietes_invazines` /
+ * `radavietes_svetimzemes` layers) reads photos, description, activity /
+ * evolution and first/last observation dates from this view. The `latest`
+ * and `observations` subqueries took ANY form with a place_id, so a form
+ * marked irrelevant (or not approved) still supplied the displayed info.
+ * Filter both to APPROVED relevant forms — the same set place geometry is
+ * built from (rusys_get_place_data_from_relevant_forms).
+ *
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function (knex) {
+  return knex.schema
+    .raw(`DROP INDEX IF EXISTS places_with_taxonomies_geom_idx`)
+    .dropMaterializedView('placesWithTaxonomies')
+    .createMaterializedView('placesWithTaxonomies', (view) => {
+      const relevantForms = (builder) =>
+        builder
+          .whereNotNull('place_id')
+          .where('status', 'APPROVED')
+          .where(knex.raw(`is_relevant IS TRUE`));
+
+      const latest = relevantForms(
+        knex
+          .select(
+            knex.raw('DISTINCT ON (place_id) place_id'),
+            'id',
+            'activity',
+            'evolution',
+            'description',
+            'photos',
+            'observed_at',
+          )
+          .from('forms'),
+      )
+        .orderBy('place_id')
+        .orderBy('observed_at', 'desc')
+        .as('latest');
+
+      const latestTranslates = knex
+        .select(
+          'latest.id',
+          knex.raw(`min(fsoa.value) as latest_activity_translate`),
+          knex.raw(`min(fsoe.value) as latest_evolution_translate`),
+        )
+        .from(latest)
+        .leftJoin(
+          'formSettingsOptions as fsoa',
+          knex.raw(`fsoa.name = latest.activity AND fsoa.group = 'ACTIVITY'`),
+        )
+        .leftJoin(
+          'formSettingsOptions as fsoe',
+          knex.raw(`fsoe.name = latest.evolution AND fsoe.group = 'EVOLUTION'`),
+        )
+        .groupBy('latest.id')
+        .as('latest_translates');
+
+      const observations = relevantForms(
+        knex
+          .select(
+            'place_id',
+            knex.raw('min(observed_at) as first_observed_at'),
+            knex.raw('max(observed_at) as last_observed_at'),
+          )
+          .from('forms'),
+      )
+        .groupBy('place_id')
+        .as('observations');
+
+      view.as(
+        knex
+          .select(
+            'p.id',
+            'p.code',
+            'p.status',
+            'p.geom',
+            'p.createdAt',
+            'p.createdBy',
+            'p.updatedAt',
+            'p.updatedBy',
+            'p.deletedAt',
+            'p.deletedBy',
+            't.*',
+            'observations.first_observed_at as firstObservedAt',
+            'observations.last_observed_at as lastObservedAt',
+            'latest.description',
+            'latest.photos',
+            'latest_translates.latest_activity_translate as activity_translate',
+            'latest_translates.latest_evolution_translate as evolution_translate',
+            'mhg.id as hexagonGridId',
+            knex.raw(`
+                ROUND(ST_X(ST_PointOnSurface(p.geom))::numeric, 2)
+                  || ' ' ||
+                ROUND(ST_Y(ST_PointOnSurface(p.geom))::numeric, 2)
+                AS center_coordinates
+              `),
+            knex.raw(`ROUND(ST_Area(p.geom)::numeric, 2) AS area`),
+          )
+          .from('places as p')
+          .leftJoin('taxonomiesAll as t', 't.speciesId', 'p.speciesId')
+          .leftJoin(
+            'mapsHexagonGrid as mhg',
+            knex.raw(`ST_Intersects(mhg.geom, ST_Centroid(p.geom))`),
+          )
+          .leftJoin(observations, 'observations.place_id', 'p.id')
+          .leftJoin(latest, 'latest.place_id', 'p.id')
+          .leftJoin(latestTranslates, 'latest_translates.id', 'latest.id'),
+      );
+    }).raw(`
+        CREATE INDEX places_with_taxonomies_geom_idx
+        ON places_with_taxonomies USING GIST (geom)
+      `);
+};
+
+/**
+ * Restores the unfiltered definition from 20251124102012.
+ *
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function (knex) {
+  return knex.schema
+    .raw(`DROP INDEX IF EXISTS places_with_taxonomies_geom_idx`)
+    .dropMaterializedView('placesWithTaxonomies')
+    .createMaterializedView('placesWithTaxonomies', (view) => {
+      const latest = knex
+        .select(
+          knex.raw('DISTINCT ON (place_id) place_id'),
+          'id',
+          'activity',
+          'evolution',
+          'description',
+          'photos',
+          'observed_at',
+        )
+        .from('forms')
+        .whereNotNull('place_id')
+        .orderBy('place_id')
+        .orderBy('observed_at', 'desc')
+        .as('latest');
+
+      const latestTranslates = knex
+        .select(
+          'latest.id',
+          knex.raw(`min(fsoa.value) as latest_activity_translate`),
+          knex.raw(`min(fsoe.value) as latest_evolution_translate`),
+        )
+        .from(latest)
+        .leftJoin(
+          'formSettingsOptions as fsoa',
+          knex.raw(`fsoa.name = latest.activity AND fsoa.group = 'ACTIVITY'`),
+        )
+        .leftJoin(
+          'formSettingsOptions as fsoe',
+          knex.raw(`fsoe.name = latest.evolution AND fsoe.group = 'EVOLUTION'`),
+        )
+        .groupBy('latest.id')
+        .as('latest_translates');
+
+      const observations = knex
+        .select(
+          'place_id',
+          knex.raw('min(observed_at) as first_observed_at'),
+          knex.raw('max(observed_at) as last_observed_at'),
+        )
+        .from('forms')
+        .whereNotNull('place_id')
+        .groupBy('place_id')
+        .as('observations');
+
+      view.as(
+        knex
+          .select(
+            'p.id',
+            'p.code',
+            'p.status',
+            'p.geom',
+            'p.createdAt',
+            'p.createdBy',
+            'p.updatedAt',
+            'p.updatedBy',
+            'p.deletedAt',
+            'p.deletedBy',
+            't.*',
+            'observations.first_observed_at as firstObservedAt',
+            'observations.last_observed_at as lastObservedAt',
+            'latest.description',
+            'latest.photos',
+            'latest_translates.latest_activity_translate as activity_translate',
+            'latest_translates.latest_evolution_translate as evolution_translate',
+            'mhg.id as hexagonGridId',
+            knex.raw(`
+                ROUND(ST_X(ST_PointOnSurface(p.geom))::numeric, 2)
+                  || ' ' ||
+                ROUND(ST_Y(ST_PointOnSurface(p.geom))::numeric, 2)
+                AS center_coordinates
+              `),
+            knex.raw(`ROUND(ST_Area(p.geom)::numeric, 2) AS area`),
+          )
+          .from('places as p')
+          .leftJoin('taxonomiesAll as t', 't.speciesId', 'p.speciesId')
+          .leftJoin(
+            'mapsHexagonGrid as mhg',
+            knex.raw(`ST_Intersects(mhg.geom, ST_Centroid(p.geom))`),
+          )
+          .leftJoin(observations, 'observations.place_id', 'p.id')
+          .leftJoin(latest, 'latest.place_id', 'p.id')
+          .leftJoin(latestTranslates, 'latest_translates.id', 'latest.id'),
+      );
+    })
+    .raw(
+      `CREATE INDEX places_with_taxonomies_geom_idx ON places_with_taxonomies USING GIST (geom)`,
+    );
+};


### PR DESCRIPTION
## What
Follow-up to #153 (same reported issue, item 216848727). The geometry fix landed, but the map identify popup still showed the **irrelevant anketa's data**: `places_with_taxonomies` builds photos, description, activity/evolution and first/last observation dates from its `latest`/`observations` subqueries, which took ANY form with a `place_id` — no `status`/`is_relevant` filter. A place whose newest form was marked irrelevant kept displaying that form's photos and dates (both SRIS `radavietes` and INVA `radavietes_invazines`/`radavietes_svetimzemes` layers read this view).

The migration recreates the view with both subqueries filtered to `status = 'APPROVED' AND is_relevant IS TRUE` — the same form set place geometry derives from. `down()` restores the 20251124 definition.

## Notes
- Verified live on local DB: place with an older relevant form (photos A, 2025-01-01) + newer irrelevant form (photos B, 2025-08-06) — before: popup data showed B and last observation 2025-08-06; after: A and 2025-01-01. Rollback/reapply verified.
- The view is recreated fresh at boot, so no separate backfill is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)